### PR TITLE
Add FFMPEG_BIN and FFMPEG_ARGS environment variables for FFMPEG customization

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,7 +4,7 @@ Cerebro is a general-purpose Discord bot with Quality of Life features.
 
 ## Features
 
-- **YliProxy**: Converts Ylilauta AV1 videos to H.264 format for proper Discord embedding
+- **YliProxy**: Converts Ylilauta AV1 videos to H.264 format (by default) for proper Discord embedding
   - Includes video list indexer with thumbnails
   - Solves the issue of Discord not supporting AV1 video embeds
 
@@ -16,7 +16,8 @@ Cerebro is a general-purpose Discord bot with Quality of Life features.
 
 **Prerequisites:**
 
-- **FFMPEG** must be installed and available in your ``PATH``
+- **FFMPEG** must be installed and available in your ``PATH`` \
+  or pointed to with the `FFMPEG_BIN` environment variable.
 - **OpenSSL** development libraries
 
 ### Using Nix
@@ -42,14 +43,16 @@ A standalone Dockerfile is planned for future releases.
 
 ## Documentation
 
-| Variable       | Description                               | Example                   |
-|----------------|-------------------------------------------|---------------------------|
-| DISCORD_TOKEN  | Discord bot authentication token          | *Required*                |
-| WEBSERVER_HOST | Host address for the web server           | ```127.0.0.1```           |
-| WEBSERVER_PORT | Port for the web server                   | ```8080```                |
-| PUBLIC_URL     | Public URL for accessing converted videos | ```https://example.com``` |
-| RUST_LOG       | Controls logging level                    | ```info```                |
-| DATA_PATH      | Path to store data files                  | ```./data```              |
+| Variable       | Description                                                        | Example                   |
+|----------------|--------------------------------------------------------------------|---------------------------|
+| DISCORD_TOKEN  | Discord bot authentication token                                   | *Required*                |
+| WEBSERVER_HOST | Host address for the web server                                    | ```127.0.0.1```           |
+| WEBSERVER_PORT | Port for the web server                                            | ```8080```                |
+| PUBLIC_URL     | Public URL for accessing converted videos                          | ```https://example.com``` |
+| RUST_LOG       | Controls logging level                                             | ```info```                |
+| DATA_PATH      | Path to store data files                                           | ```./data```              |
+| FFMPEG_BIN     | Name or path to the FFMPEG binary                                  | ```ffmpeg-static-6```     |
+| FFMPEG_ARGS    | FFMPEG arguments template with `$INPUT` and `$OUTPUT` placeholders | ```-y -i $INPUT -vaapi_device /dev/dri/renderD128 -vf format=nv12,hwupload -c:v h264_vaapi -c:a copy $OUTPUT``` |
 
 ## License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/src/bot/services/yliproxy.rs
+++ b/src/bot/services/yliproxy.rs
@@ -18,24 +18,14 @@ impl YliProxy {
     pub async fn convert_to_h264(input_path: &Path, id: &str) -> Result<PathBuf> {
         let file_name = format!("{}.mp4", id);
         let output_file = Path::new(&CONFIG.converted_dir).join(&file_name);
+        let ffmpeg_args = CONFIG
+            .ffmpeg_args
+            .replace("$INPUT", input_path.to_str().unwrap())
+            .replace("$OUTPUT", output_file.to_str().unwrap());
+        let ffmpeg_args: Vec<&str> = ffmpeg_args.split_whitespace().collect();
 
-        let output = Command::new("ffmpeg")
-            .args([
-                "-y",
-                "-i",
-                input_path.to_str().unwrap(),
-                "-c:v",
-                "libx264",
-                "-preset",
-                "veryfast",
-                "-crf",
-                "23",
-                "-threads",
-                "4",
-                "-c:a",
-                "copy",
-                output_file.to_str().unwrap(),
-            ])
+        let output = Command::new(&CONFIG.ffmpeg_bin)
+            .args(ffmpeg_args)
             .output()
             .await?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@ pub struct Config {
     pub discord_token: String,
     pub download_dir: String,
     pub converted_dir: String,
+    pub ffmpeg_bin: String,
+    pub ffmpeg_args: String,
     pub host: String,
     pub port: u16,
     pub public_url: String,
@@ -17,6 +19,24 @@ impl Config {
         let data_path = env::var("DATA_PATH").unwrap_or(".".to_string());
         let download_dir = format!("{}/downloads", data_path);
         let converted_dir = format!("{}/converted", data_path);
+
+        let ffmpeg_bin = env::var("FFMPEG_BIN").unwrap_or("ffmpeg".to_string());
+        let ffmpeg_args = env::var("FFMPEG_ARGS").unwrap_or(
+            "-y ".to_string()
+                + "-i "
+                + "$INPUT "
+                + "-c:v "
+                + "libx264 "
+                + "-preset "
+                + "veryfast "
+                + "-crf "
+                + "23 "
+                + "-threads "
+                + "4 "
+                + "-c:a "
+                + "copy "
+                + "$OUTPUT",
+        );
 
         let host = env::var("WEBSERVER_HOST").unwrap_or("127.0.0.1".to_string());
         let port = env::var("WEBSERVER_PORT")
@@ -31,6 +51,8 @@ impl Config {
             public_url,
             download_dir,
             converted_dir,
+            ffmpeg_bin,
+            ffmpeg_args,
             host,
             port,
         }


### PR DESCRIPTION
This PR adds the `FFMPEG_BIN` and `FFMPEG_ARGS` environment variables for customizing the FFMPEG arguments and to optionally use a custom binary if needed (e.g. hardware encoding support). 